### PR TITLE
Ignore .edib.log during rsync

### DIFF
--- a/edib/prerequisites.mk
+++ b/edib/prerequisites.mk
@@ -10,6 +10,7 @@ move-app: $(APP_DIR)
 $(APP_DIR):
 	rsync -av \
 		--exclude=.git\
+		--exclude=.edib.log \
 		--exclude=_build \
 		--exclude=deps \
 		--exclude=node_modules \


### PR DESCRIPTION
Syncing `.edib.log` while being opened in `tail` makes `rsync` fail:

```
| sending incremental file list                                        
| rsync: readlink_stat("/source/.edib.log") failed: Protocol error (71)
...
| rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1178) [sender=3.1.2]
| sent 33,997 bytes  received 759 bytes  69,512.00 bytes/sec
| total size is 31,065  speedup is 0.89
| edib/prerequisites.mk:11: recipe for target '/build/app' failed
| make[1]: Leaving directory '/build'
| make[1]: *** [/build/app] Error 23
| edib/Makefile:9: recipe for target 'prerequisites' failed
| make: *** [prerequisites] Error 2
```